### PR TITLE
Move the CUDA header into appropriate position

### DIFF
--- a/include/densecrf_gpu.cuh
+++ b/include/densecrf_gpu.cuh
@@ -3,8 +3,7 @@
 #include "densecrf_base.h"
 #include "pairwise_gpu.cuh"
 #include <vector>
-#include <cuda_runtime.h>
-#include <device_launch_parameters.h>
+
 
 namespace dcrf_cuda {
 

--- a/include/permutohedral_gpu.cuh
+++ b/include/permutohedral_gpu.cuh
@@ -28,6 +28,10 @@ SOFTWARE.*/
 #include <utility>
 #include <iostream>
 
+#include <cuda_runtime.h>
+#include <device_launch_parameters.h>
+#include <device_atomic_functions.h>
+
 namespace dcrf_cuda {
 
 


### PR DESCRIPTION
The cuda header is better to be included in permutohedral.cuh so those headers can be safely included as a third-party dependencies. 